### PR TITLE
Add a protocol MACRO for allowing HTTPS mod_status access

### DIFF
--- a/Template App Apache2 HTTP.xml
+++ b/Template App Apache2 HTTP.xml
@@ -399,7 +399,7 @@ https://httpd.apache.org/docs/current/mod/mod_status.html</description>
                     <preprocessing/>
                     <jmx_endpoint/>
                     <timeout>3s</timeout>
-                    <url>http://{HOST.CONN}:{$STUB_STATUS_PORT}/{$STUB_STATUS_PATH}</url>
+                    <url>{$STUB_STATUS_PROTOCOL}://{HOST.CONN}:{$STUB_STATUS_PORT}/{$STUB_STATUS_PATH}</url>
                     <query_fields/>
                     <posts/>
                     <status_codes/>
@@ -824,6 +824,10 @@ https://httpd.apache.org/docs/current/mod/mod_status.html</description>
             <discovery_rules/>
             <httptests/>
             <macros>
+                <macro>
+                    <macro>{$STUB_STATUS_PROTOCOL}</macro>
+                    <value>http</value>
+                </macro>
                 <macro>
                     <macro>{$STUB_STATUS_PATH}</macro>
                     <value>server-status?auto</value>


### PR DESCRIPTION
Hi,

I wasn't able to get data from a server with HTTP to HTTPS redirection enabled (302 HTTP status code) until I did the combination of changing the protocol to https and setting the `STUB_STATUS_PORT` to 443.

HTTP to HTTPS redirection was triggering "Failed to fetch apache2 server status page" because of the status code.

I added a MACRO named `STUB_STATUS_PROTOCOL`, default value is `http` and changing it to `https` allowed me to avoid the redirection.
Setting the `STUB_STATUS_PORT` to 443 wasn't enough for solving it if the protocol wasn't changed.

I think this might be useful for other users.